### PR TITLE
Replace gulp-tar with gulp-tar-path to include subfolders and subfiles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var sass = require('gulp-sass');
 var sourcemaps = require('gulp-sourcemaps');
-var tar = require('gulp-tar');
+var tar = require('gulp-tar-path');
 var gzip = require('gulp-gzip');
 var clean = require('gulp-clean');
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "gulp-gzip": "^1.4.0",
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.9.1",
-    "gulp-tar": "^1.9.0"
+    "gulp-tar-path": "^1.0.1"
   }
 }


### PR DESCRIPTION
The current `.tar.gz` has empty folders. This will fix it and include folders & files in subfolders too.