### PR TITLE
Improve overall look of the navigation for docs.gitea.io

### DIFF
--- a/layouts/partials/pages.html
+++ b/layouts/partials/pages.html
@@ -3,10 +3,8 @@
 		{{ $currentNode := . }}{{ range .Site.Menus.sidebar }}
 			{{ if .HasChildren }}
 				<li class="nav-item">
-					<a class="nav-link" href="#">
-						{{ .Pre }}
-						{{ .Name }}
-					</a>
+					{{ .Pre }}
+					{{ .Name }}
 					<ul>
 						{{ range .Children }}
 							<li class="nav-item">

--- a/layouts/post/list.html
+++ b/layouts/post/list.html
@@ -3,7 +3,7 @@
 
 <div class="container content">
 	<div class="row">
-		<div class="col-xs-12">
+		<div class="col-lg-8 offset-lg-2">
 			{{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}{{ range $paginator.Pages }}
 				<article>
 					<header>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -3,7 +3,7 @@
 
 <div class="container content">
 	<div class="row">
-		<div class="col-xs-12">
+		<div class="col-lg-8 offset-lg-2">
 			<article>
 				<header>
 					<h2>
@@ -23,14 +23,16 @@
 				</header>
 
 				{{ .Content }}
+
+				{{ if .Site.DisqusShortname }}
+					<div class="row">
+						<div class="col-xs-12">
+							{{ partial "disqus.html" . }}
+						</div>
+					</div>
+				{{ end }}
 			</article>
 		</div>
-
-		{{ if .Site.DisqusShortname }}
-			<div class="col-xs-12">
-				{{ partial "disqus.html" . }}
-			</div>
-		{{ end }}
 	</div>
 </div>
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -43,7 +43,9 @@
 }
 
 aside ul.nav {
-  border-right: 1px solid lighten($accent-color, 30);
+  @include media-breakpoint-up(sm) {
+    border-right: 1px solid lighten($accent-color, 30);
+  }
 
   ul {
     margin: 0;


### PR DESCRIPTION
Improve overall look of the navigation for docs.gitea.io
Additionally the blog post content isn't 12 wide for lg anymore. Rather 8 and centered, way better to read.

New styles for the navigation.

![screenshot from 2016-12-23 19-59-36](https://cloud.githubusercontent.com/assets/872251/21460613/916d19fa-c94a-11e6-9071-ccc4e42161b9.png)

No border-right for the navigation for smaller devices
![download](https://cloud.githubusercontent.com/assets/872251/21460614/935ae4cc-c94a-11e6-904c-05312bbdd8b2.png)
