### PR TITLE
Specify widths of content containers to enable reading of docker article

### DIFF
--- a/layouts/doc/single.html
+++ b/layouts/doc/single.html
@@ -7,7 +7,7 @@
 			<div class="column is-one-quarter">
 				{{ partial "menu" . }}
 			</div>
-			<div class="column">
+			<div class="column is-three-quarters">
 				<div class=" content">
 					{{ .Content }}
 				</div>

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -7,7 +7,7 @@
 			<div class="column is-one-quarter">
 				{{ partial "menu" . }}
 			</div>
-			<div class="column">
+			<div class="column is-three-quarters">
 				<div class=" content">
 					{{ .Content }}
 				</div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/646061/52305191-c8d4f480-2951-11e9-893c-5fba7d77f932.png)

will become

![image](https://user-images.githubusercontent.com/646061/52305227-dee2b500-2951-11e9-9af5-7979f5211bfc.png)

Although because this fixes the problem for this page, the culprit is likely in the styling of the `<code/>` element, because it doesn't appear on pages without code blocks. 