### PR TITLE
Fixed docs content page overflow

### DIFF
--- a/layouts/doc/single.html
+++ b/layouts/doc/single.html
@@ -7,8 +7,8 @@
 			<div class="column is-one-quarter">
 				{{ partial "menu" . }}
 			</div>
-			<div class="column">
-				<div class=" content">
+			<div class="column is-three-quarters">
+				<div class="content">
 					{{ .Content }}
 				</div>
 			</div>


### PR DESCRIPTION
This pr fixes the following bug:

![grafik](https://user-images.githubusercontent.com/13721712/56091719-8defbf80-5eb2-11e9-903f-b2ffa1dcf60a.png)

Now:
![grafik](https://user-images.githubusercontent.com/13721712/56091727-a9f36100-5eb2-11e9-9f05-6f9c0a291303.png)
